### PR TITLE
Update dataloader wrappers + print git hash

### DIFF
--- a/src/stuned/local_datasets/utils.py
+++ b/src/stuned/local_datasets/utils.py
@@ -306,13 +306,7 @@ def subsample_dataloader_randomly(dataloader, fraction, batch_size=None):
 
     new_dataloader = DataLoader(**dataloader_init_args)
 
-    custom_properties = properties_diff(dataloader, new_dataloader)
-    for custom_property in custom_properties:
-        setattr(
-            new_dataloader,
-            custom_property,
-            getattr(dataloader, custom_property)
-        )
+    add_custom_properties(dataloader, new_dataloader)
 
     if dataloader_is_wrapper:
         if wrapper is not None:
@@ -323,6 +317,16 @@ def subsample_dataloader_randomly(dataloader, fraction, batch_size=None):
                 "but it is not supported."
             )
     return new_dataloader
+
+
+def add_custom_properties(giver, taker):
+    custom_properties = properties_diff(giver, taker)
+    for custom_property in custom_properties:
+        setattr(
+            taker,
+            custom_property,
+            getattr(giver, custom_property)
+        )
 
 
 def get_dataloader_init_args_from_existing_dataloader(
@@ -485,7 +489,13 @@ def wrap_dataloader(wrappable, wrapper, **kwargs):
     if isinstance(wrappable, list):
         return ManyDataloadersWrapper(wrappable, wrapper, **kwargs)
     else:
-        return SingleDataloaderWrapper(wrappable, wrapper, **kwargs)
+        wrapped_dataloader = SingleDataloaderWrapper(
+            wrappable,
+            wrapper,
+            **kwargs
+        )
+        add_custom_properties(wrappable, wrapped_dataloader)
+        return wrapped_dataloader
 
 
 def get_generic_train_eval_dataloaders(
@@ -665,3 +675,16 @@ class ChainingIteratorsWrapper:
 
 def chain_dataloaders(dataloaders_list):
     return wrap_dataloader(dataloaders_list, ChainingIteratorsWrapper)
+
+
+class DropLastIteratorWrapper:
+
+    def __init__(self, iterator):
+        self.iterator = iterator
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        next_item = next(self.iterator)
+        return next_item[:-1]

--- a/src/stuned/local_datasets/utils.py
+++ b/src/stuned/local_datasets/utils.py
@@ -37,7 +37,8 @@ from utility.utils import (
     deterministically_subsample_indices_uniformly,
     show_images,
     append_dict,
-    compute_proportion
+    compute_proportion,
+    properties_diff
 )
 sys.path.pop(0)
 
@@ -304,6 +305,14 @@ def subsample_dataloader_randomly(dataloader, fraction, batch_size=None):
         dataloader_init_args["batch_size"] = batch_size
 
     new_dataloader = DataLoader(**dataloader_init_args)
+
+    custom_properties = properties_diff(dataloader, new_dataloader)
+    for custom_property in custom_properties:
+        setattr(
+            new_dataloader,
+            custom_property,
+            getattr(dataloader, custom_property)
+        )
 
     if dataloader_is_wrapper:
         if wrapper is not None:

--- a/src/stuned/utility/helpers_for_main.py
+++ b/src/stuned/utility/helpers_for_main.py
@@ -1,4 +1,5 @@
 import argparse
+import git
 
 
 # local modules
@@ -59,6 +60,10 @@ def prepare_wrapper_for_experiment(check_config=None, patch_config=None):
                     start_time=None,
                     config_to_log_in_wandb=experiment_config
                 ) as logger:
+
+                    repo = git.Repo(search_parent_directories=True)
+                    sha = repo.head.object.hexsha
+                    logger.log(f"Hash of current git commit: {sha}")
 
                     if check_config is not None:
                         logger.log(

--- a/src/stuned/utility/utils.py
+++ b/src/stuned/utility/utils.py
@@ -1768,3 +1768,11 @@ def get_with_assert(container, key, error_msg=None):
 
     assert key in container, error_msg
     return container[key]
+
+
+def properties_diff(first_object, second_object):
+    return (
+        set(first_object.__dict__.keys()).difference(
+            set(second_object.__dict__.keys())
+        )
+    )

--- a/src/stuned/utility/utils.py
+++ b/src/stuned/utility/utils.py
@@ -1776,3 +1776,19 @@ def properties_diff(first_object, second_object):
             set(second_object.__dict__.keys())
         )
     )
+
+
+def get_even_from_wrapped(giver, wrappable_as_property, property_to_get):
+
+    if hasattr(giver, property_to_get):
+        return getattr(
+            giver,
+            property_to_get
+        )
+    elif hasattr(giver, wrappable_as_property):
+        return get_even_from_wrapped(
+            getattr(giver, wrappable_as_property),
+            wrappable_as_property,
+            property_to_get
+        )
+    return None


### PR DESCRIPTION
- Dataloader wrappers can take any kwargs.
- Dataloader wrappers copy properties from dataloaders they wrap.
- Git hash is printed in logs.

## Battle tests
- Correct hash printed during training - ok.
- Wrapped dataloaders have properties from dataloaders they wrap - ok.