### PR TITLE
Log in wandb even with steps smaller than current.

### DIFF
--- a/src/stuned/utility/logger.py
+++ b/src/stuned/utility/logger.py
@@ -745,8 +745,11 @@ def try_to_sync_csv_with_remote(logger, sync_row_zero=True):
 
 
 def try_to_log_in_wandb(logger, dict_to_log, step):
-    if logger.wandb_run is not None:
-        logger.wandb_run.log(dict_to_log, step=step)
+    wandb_run = logger.wandb_run
+    if wandb_run is not None:
+        if step <= wandb_run.step:
+            step = wandb_run.step + 1
+        wandb_run.log(dict_to_log, step=step)
 
 
 def try_to_log_in_tb(


### PR DESCRIPTION
- Log in wandb even when step is smaller than current (tested in 1).

Tests:
- 1: [[AADJL.T] Stable step for wandb](https://www.notion.so/AADJL-T-Stable-step-for-wandb-a6d3b567e6bf4bfe985d66c429f860b7?pvs=4).