### PR TITLE
Allow nested keys for get_with_assert

### DIFF
--- a/src/stuned/utility/utils.py
+++ b/src/stuned/utility/utils.py
@@ -1770,11 +1770,21 @@ def prune_list(l, value):
 
 def get_with_assert(container, key, error_msg=None):
 
-    if error_msg is None:
-        error_msg = f"Key \"{key}\" not in container: {container}"
-
-    assert key in container, error_msg
-    return container[key]
+    if isinstance(key, str):
+        if error_msg is None:
+            error_msg = f"Key \"{key}\" not in container: {container}"
+        assert key in container, error_msg
+        return container[key]
+    else:
+        assert isinstance(key, list)
+        assert len(key) > 0
+        next_key = key[0]
+        rest_key = key[1:]
+        next_container = get_with_assert(container, next_key, error_msg)
+        if len(rest_key) == 0:
+            return next_container
+        else:
+            return get_with_assert(next_container, rest_key, error_msg)
 
 
 def properties_diff(first_object, second_object):


### PR DESCRIPTION
- Allow nested keys for get_with_assert (tested by 1).

Tests:
- 1: [[AADJL.T] Diversity weight is recomputed correctly](https://www.notion.so/AADJL-T-Diversity-weight-is-recomputed-correctly-866d71ab1168422bab74ab9e18ac58e0?pvs=4).