### PR TITLE
Local csv for each experiment

### DIFF
--- a/src/stuned/local_datasets/utils.py
+++ b/src/stuned/local_datasets/utils.py
@@ -38,7 +38,7 @@ from utility.utils import (
     show_images,
     append_dict,
     compute_proportion,
-    properties_diff
+    add_custom_properties
 )
 sys.path.pop(0)
 
@@ -317,16 +317,6 @@ def subsample_dataloader_randomly(dataloader, fraction, batch_size=None):
                 "but it is not supported."
             )
     return new_dataloader
-
-
-def add_custom_properties(giver, taker):
-    custom_properties = properties_diff(giver, taker)
-    for custom_property in custom_properties:
-        setattr(
-            taker,
-            custom_property,
-            getattr(giver, custom_property)
-        )
 
 
 def get_dataloader_init_args_from_existing_dataloader(

--- a/src/stuned/run_from_csv/__main__.py
+++ b/src/stuned/run_from_csv/__main__.py
@@ -23,7 +23,8 @@ from utility.utils import (
     normalize_path,
     check_duplicates,
     expand_csv,
-    retrier_factory
+    retrier_factory,
+    is_number
 )
 from utility.configs import (
     AUTOGEN_PREFIX,
@@ -326,7 +327,7 @@ def process_csv_row(
     whether_to_run = csv_row[WHETHER_TO_RUN_COLUMN]
 
     if (
-        whether_to_run.isnumeric()
+        is_number(whether_to_run)
             and int(whether_to_run) != 0
     ):
 
@@ -510,7 +511,7 @@ def make_new_config(
 
 def replace_placeholders(csv_row, placeholder, new_value):
     for column_name, value in csv_row.items():
-        csv_row[column_name] = value.replace(placeholder, new_value)
+        csv_row[column_name] = str(value).replace(placeholder, new_value)
 
 
 def make_task_cmd(new_config_path, conda_env, exec_path):

--- a/src/stuned/utility/logger.py
+++ b/src/stuned/utility/logger.py
@@ -831,7 +831,8 @@ def redneck_logger_context(
             logger.output_folder,
             "local_copy_" + os.path.basename(csv_path)
         )
-        shutil.copy(csv_path, local_csv_path)
+        with make_file_lock(csv_path):
+            shutil.copy(csv_path, local_csv_path)
         output_config[PATH_KEY] = local_csv_path
         logger.set_csv_output(
             output_config


### PR DESCRIPTION
- Add pandas-based versions of writing in csv (tested by 1).
- Use local csv copies for experiment runners (tested by 2).

Tests:
- 1: [[AADJL.T] Writing into csv](https://www.notion.so/AADJL-T-Writing-into-csv-9b5fb661c2504b9f99988c2b807b7e34?pvs=4).
- 2: [[AADJL.T] Many experiments in parallel work](https://www.notion.so/AADJL-T-Many-experiments-in-parallel-work-5242691e54de47018e37a91827f6ef28?pvs=4).