### PR TITLE
Update off-diag percent addition

### DIFF
--- a/src/stuned/local_datasets/features_labeller.py
+++ b/src/stuned/local_datasets/features_labeller.py
@@ -420,8 +420,7 @@ class FeaturesLabeller:
             if off_diag_percent > 0:
 
                 off_diag_addition_train_dataloader, _ = \
-                    self._get_dataloaders_for_dataset_name(
-                        self.off_diag_names[0],
+                    self._get_multilabelled_dataloaders_for_off_diag(
                         train_batch_size,
                         0,
                         num_workers,
@@ -438,7 +437,8 @@ class FeaturesLabeller:
                     [
                         train_loaders[self.diag_name],
                         off_diag_addition_train_dataloader
-                    ]
+                    ],
+                    random_order=True
                 )
 
             if single_label:

--- a/src/stuned/utility/imports.py
+++ b/src/stuned/utility/imports.py
@@ -9,7 +9,8 @@ import copy
 # local modules
 from .utils import (
     error_or_print,
-    get_nested_attr
+    get_nested_attr,
+    get_with_assert
 )
 
 
@@ -190,8 +191,7 @@ def import_from_string(string, reload=False, nested_attrs_depth=1):
 
 def make_from_class_ctor(from_class_config, pos_args_list=[]):
 
-    assert "class" in from_class_config
-    class_ctor = import_from_string(from_class_config["class"])
+    class_ctor = import_from_string(get_with_assert(from_class_config, "class"))
     kwargs = from_class_config.get("kwargs", {})
     importable_kwargs = from_class_config.get("kwargs_to_import", {})
 


### PR DESCRIPTION
- Add option to chain dataloaders in random order (tested by 1)
- Provide all off-diag labels when adding off-diag percent to diagonal train dataset and intervene off-diag samples with diagonal samples (tested by 2)
- Use get_with_assert in from_class_ctor (tested by 3)

Tests:
- 1: [[AADJL.T] Chaining dataloaders](https://www.notion.so/AADJL-T-Chaining-dataloaders-75e2b5e6b00041519cd704a3247a024e?pvs=4)
- 2: [[AADJL.T] Clean and mixed supervision off-diag percent](https://www.notion.so/AADJL-T-Clean-and-mixed-supervision-off-diag-percent-0cc21838221f439c9f60c936202d74e2?pvs=4)
- 3: [[AADJL.T] Reduce on plateau scheduler](https://www.notion.so/AADJL-T-Reduce-on-plateau-scheduler-19a39d9fd5694ee88b4ee2e1b98b8843?pvs=4)