### PR TITLE
Add ability to have a list of paths in the config.

### DIFF
--- a/src/stuned/utility/utils.py
+++ b/src/stuned/utility/utils.py
@@ -1208,6 +1208,7 @@ def normalize_path(path, current_dir=None):
     else:
         raise ValueError(f"Path must be either str or list, got {type(path)}")
 
+
 def read_json(json_path):
     with open(json_path, 'r') as f:
         json_contents = json.load(f)

--- a/src/stuned/utility/utils.py
+++ b/src/stuned/utility/utils.py
@@ -1187,18 +1187,26 @@ def read_csv_as_dict_pd(
     return result
 
 
-def normalize_path(path, current_dir=None):
+def normalize_string_path(path, current_dir):
     if current_dir is None:
         current_dir = get_project_root_path()
-    if path is None:
-        return None
-    assert isinstance(path, str)
-    assert path
     path = os.path.expanduser(path)
     if path[0] == '.':
         path = os.path.join(current_dir, path)
     return os.path.abspath(path)
 
+
+def normalize_path(path, current_dir=None):
+    if path is None:
+        return None
+    if isinstance(path, str):
+        assert path
+        return normalize_string_path(path, current_dir)
+    elif isinstance(path, list):
+        assert path
+        return [normalize_string_path(p, current_dir) for p in path]
+    else:
+        raise ValueError(f"Path must be either str or list, got {type(path)}")
 
 def read_json(json_path):
     with open(json_path, 'r') as f:

--- a/tests/config_reading.py
+++ b/tests/config_reading.py
@@ -1,0 +1,37 @@
+import os
+import unittest
+from unittest import mock
+
+import stuned.utility.utils as utils
+import stuned.utility.configs as configs
+
+TEST_CONFIG_PATH = "test_config.yaml"
+
+
+class TestPathNormalization(unittest.TestCase):
+
+    def setUp(self):
+        self.config = utils.read_yaml(TEST_CONFIG_PATH)
+
+    def test_path_normalization_same_for_str_and_list(self):
+        str_keys = ["path0", "path1", "path2", "path3"]
+        list_key = "paths"
+
+        # Check that paths are found in config
+        paths_in_config = configs.find_nested_keys_by_keyword_in_config(
+            self.config,
+            "path",
+        )
+        self.assertEqual(
+            paths_in_config,
+            str_keys + [list_key],
+        )
+
+        configs.normalize_paths(self.config, paths_in_config)
+
+        str_paths = [self.config[key] for key in str_keys]
+        list_paths  = self.config[list_key]
+
+        # Check that normalization does to lists the same as to strings
+        for p_str, p_list in zip(str_paths, list_paths):
+            self.assertEqual(p_str, p_list)

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,0 +1,12 @@
+experiment_name: test_experiment
+
+path0: 'hello'
+path1: '.world'
+path2: '~/machine'
+path3: '/learning'
+
+paths:
+  - 'hello'
+  - '.world'
+  - '~/machine'
+  - '/learning'


### PR DESCRIPTION
Paths are parsed by searching for 'path' substring in the key. Previously only string values were allowed, now we add list values. Also add test that path normalization on a list-value does the same to each element as to a string value.