### PR TITLE
Manual values for feature labeller

### DIFF
--- a/src/stuned/local_datasets/dsprites.py
+++ b/src/stuned/local_datasets/dsprites.py
@@ -349,6 +349,12 @@ class BaseDataDSprites(BaseData):
             assert isinstance(self.pruned_indices, set)
 
         self.transform = transform
+        features_sizes = np.array(
+            [
+                len(possible_features_values[feature])
+                    for feature in possible_features
+            ]
+        )
 
         super(BaseDataDSprites, self).__init__(
             possible_features,

--- a/src/stuned/local_datasets/from_folder.py
+++ b/src/stuned/local_datasets/from_folder.py
@@ -32,7 +32,14 @@ def get_dataloaders_from_folder(
                 f"\nsplits: {splits}"
 
     def clean_splits(splits):
-        assert sum(splits.values()) == 1, \
+        sum_of_splits = sum(splits.values())
+        assert sum_of_splits >= 0 and sum_of_splits <= 1, \
+            "Sum of splits for \"from_folder\" dataset should be in [0, 1] range"
+        for split_name, split_size in splits.items():
+            if split_size is None:
+                splits[split_name] = 1 - sum_of_splits
+                sum_of_splits = 1
+        assert sum_of_splits == 1, \
             "Splits for \"from_folder\" dataset do not sum up to one"
         splits_to_pop = []
         for split_name, split_size in splits.items():

--- a/src/stuned/utility/configs.py
+++ b/src/stuned/utility/configs.py
@@ -104,7 +104,7 @@ def find_nested_keys_by_keyword_in_config(
                 config[key],
                 keyword=keyword,
                 separator=separator,
-                prefix=prefix+key+separator
+                prefix=str(prefix)+str(key)+str(separator)
             )
             res.extend(subpaths)
         return res

--- a/src/stuned/utility/utils.py
+++ b/src/stuned/utility/utils.py
@@ -21,6 +21,7 @@ import signal
 import platform
 import sys
 from collections import Counter
+from collections.abc import Iterable
 import itertools
 import contextlib
 from watchdog.observers import Observer
@@ -1921,3 +1922,13 @@ def add_custom_properties(giver, taker, only_local=True):
             custom_property,
             getattr(giver, custom_property)
         )
+
+
+def invert_dict(d):
+    res = {}
+    for key, container in d.items():
+        assert isinstance(container, Iterable)
+        for value in container:
+            assert value not in res, f"Dict is not invertible: {d}"
+            res[value] = key
+    return res


### PR DESCRIPTION
- Allow manual values to classes assignment for features labeller
(tested by 1)
- Ensure string in nested path (tested by 1)
- Allow null for split size in "from_folder" dataset (not tested)

Battle tests:
1: [[AADJL.T] All datasets are visualized -> dsprites](https://www.notion.so/AADJL-T-All-datasets-are-visualized-d7bf0ab1aeda4e648ad29c61a5cb14af?pvs=4#e9d76389bebd45eaa6d7acfa2b52191a)