### PR TITLE
Expand env vars in config paths

### DIFF
--- a/src/stuned/utility/helpers_for_main.py
+++ b/src/stuned/utility/helpers_for_main.py
@@ -1,5 +1,6 @@
 import argparse
 import git
+import os
 
 
 # local modules
@@ -7,7 +8,8 @@ from .utils import (
     apply_random_seed,
     pretty_json,
     kill_processes,
-    get_project_root_path
+    get_project_root_path,
+    find_by_subkey
 )
 from .configs import (
     EXP_NAME_CONFIG_KEY,
@@ -19,6 +21,10 @@ from .logger import (
     handle_exception,
     redneck_logger_context
 )
+
+
+SCRATCH_LOCAL = os.path.join(os.path.abspath(os.sep), "scratch_local")
+SCRATCH_VAR_NAME = "SCRATCH"
 
 
 def parse_args():
@@ -40,6 +46,8 @@ def prepare_wrapper_for_experiment(check_config=None, patch_config=None):
             processes_to_kill_before_exiting = []
 
             try:
+
+                define_env_vars()
 
                 main_args = parse_args()
 
@@ -103,3 +111,18 @@ def prepare_wrapper_for_experiment(check_config=None, patch_config=None):
         return run_experiment_with_logger
 
     return wrapper_for_experiment
+
+
+def define_env_vars():
+    if SCRATCH_VAR_NAME not in os.environ:
+        user_name = os.environ.get("USER")
+        any_folder_of_user = find_by_subkey(
+            os.listdir(SCRATCH_LOCAL),
+            user_name,
+            assert_found=True,
+            only_first_occurence=True
+        )
+        os.environ[SCRATCH_VAR_NAME] = os.path.join(
+            SCRATCH_LOCAL,
+            any_folder_of_user
+        )

--- a/src/stuned/utility/utils.py
+++ b/src/stuned/utility/utils.py
@@ -82,6 +82,10 @@ PLT_PLOT_HEIGHT = 5
 PLT_PLOT_WIDTH = 5
 
 
+# regexes
+ENV_VAR_RE = re.compile(r"<([a-zA-Z0-9-_]+)>")
+
+
 class ChildrenForPicklingPreparer:
 
     def _prepare_for_pickling(self):
@@ -1194,11 +1198,18 @@ def read_csv_as_dict_pd(
 
 
 def normalize_string_path(path, current_dir):
+
     if current_dir is None:
         current_dir = get_project_root_path()
     path = os.path.expanduser(path)
     if path[0] == '.':
         path = os.path.join(current_dir, path)
+    env_vars = ENV_VAR_RE.findall(path)
+    for env_var in env_vars:
+        assert env_var in os.environ, \
+            f"Environment variable {env_var} is not set."
+        path = path.replace(f"<{env_var}>", os.environ[env_var])
+
     return os.path.abspath(path)
 
 


### PR DESCRIPTION
- Define SCRATCH var if not defined

Review:
[[AADJL.T] Give scratch local env var to paths](https://www.notion.so/AADJL-T-Give-scratch-local-env-var-to-paths-ee86ca619a584a91897ff6361ebbc464?pvs=4)