### PR TITLE
Allow service authentification for Google

### DIFF
--- a/src/stuned/utility/helpers_for_main.py
+++ b/src/stuned/utility/helpers_for_main.py
@@ -114,7 +114,7 @@ def prepare_wrapper_for_experiment(check_config=None, patch_config=None):
 
 
 def define_env_vars():
-    if SCRATCH_VAR_NAME not in os.environ:
+    if SCRATCH_VAR_NAME not in os.environ and os.path.exists(SCRATCH_LOCAL):
         user_name = os.environ.get("USER")
         any_folder_of_user = find_by_subkey(
             os.listdir(SCRATCH_LOCAL),

--- a/src/stuned/utility/logger.py
+++ b/src/stuned/utility/logger.py
@@ -1256,6 +1256,11 @@ class GspreadClient:
     @retrier_factory_with_auto_logger()
     def _create_client(self):
 
+        if os.path.exists(DEFAULT_GOOGLE_SERVICE_CREDENTIALS_PATH):
+            return gspread.service_account(
+                filename=DEFAULT_GOOGLE_SERVICE_CREDENTIALS_PATH
+            )
+
         _, auth_user_filename = make_google_auth(
             self.gspread_credentials,
             logger=self.logger
@@ -1507,7 +1512,18 @@ class GdriveClient:
     @retrier_factory_with_auto_logger()
     def _create_client(self):
 
-        gauth, _ = make_google_auth(self.credentials)
+        if os.path.exists(DEFAULT_GOOGLE_SERVICE_CREDENTIALS_PATH):
+            settings = {
+                    "client_config_backend": "service",
+                    "service_config": {
+                        "client_json_file_path":
+                            DEFAULT_GOOGLE_SERVICE_CREDENTIALS_PATH,
+                    }
+                }
+            gauth = GoogleAuth(settings=settings)
+            gauth.ServiceAuth()
+        else:
+            gauth, _ = make_google_auth(self.credentials)
         return GoogleDrive(gauth)
 
     def get_node_by_id(self, node_id):

--- a/src/stuned/utility/logger.py
+++ b/src/stuned/utility/logger.py
@@ -157,14 +157,21 @@ LOGGING_CONFIG_KEY = "logging"
 DEFAULT_SPREADSHEET_ROWS = 100
 DEFAULT_SPREADSHEET_COLS = 20
 DEFAULT_SPREADSHEET_NAME = "default_spreadsheet"
-DEFAULT_GOOGLE_CREDENTIALS_PATH = os.path.join(
+DEFAULT_GAUTH_FOLDER = os.path.join(
     os.path.expanduser('~'),
     ".config",
-    "gauth",
+    "gauth"
+)
+DEFAULT_GOOGLE_CREDENTIALS_PATH = os.path.join(
+    DEFAULT_GAUTH_FOLDER,
     "credentials.json"
 )
+DEFAULT_GOOGLE_SERVICE_CREDENTIALS_PATH = os.path.join(
+    DEFAULT_GAUTH_FOLDER,
+    "service_key.json"
+)
 DEFAULT_REFRESH_GOOGLE_CREDENTIALS = os.path.join(
-    os.path.dirname(DEFAULT_GOOGLE_CREDENTIALS_PATH),
+    DEFAULT_GAUTH_FOLDER,
     "gauth_refresh_credentials.json"
 )
 URL_ID_RE = re.compile(r"id=([a-zA-Z0-9-_]+)")
@@ -879,7 +886,7 @@ def redneck_logger_context(
         )
 
     # set up google drive sync
-    if logging_config[GDRIVE_FOLDER_KEY] is not None:
+    if logging_config.get(GDRIVE_FOLDER_KEY) is not None:
         logger.create_logs_on_gdrive(
             logging_config[GDRIVE_FOLDER_KEY]
         )


### PR DESCRIPTION
- Service auth for gspread
- Service auth for gdrive
- Scratch local env var is not added when there is no folder scratch local
- Don't require link to gdrive folder in config when creating logger

Review:
[[STUNED.T] Update gauth method](https://www.notion.so/STUNED-T-Update-gauth-method-314d0daef80a4eeab1a90e7ce563fe3d?pvs=4)